### PR TITLE
Add route button to main

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -1,7 +1,9 @@
 <div class="content">
     <nav class="navbar">
         <div class="start">
-            <img src="../../assets/images/gdsc-brackets.png">
+            <button routerLink="/">
+                <img src="../../assets/images/gdsc-brackets.png">
+            </button>
             <a>Google Developer Student Club - Missouri S&T</a>
         </div>
         <div class="end">

--- a/src/app/components/navbar/navbar.component.scss
+++ b/src/app/components/navbar/navbar.component.scss
@@ -12,9 +12,16 @@
         display: flex;
         align-items: center;
 
-        img {
-            width: 50px;
+        button {
+            background: transparent;
+            border: none;
+            cursor: pointer;
             margin-right: 15px;
+            width: 50px;
+
+            img {
+                width: 100%;
+            }
         }
 
         a {


### PR DESCRIPTION
# Issue #13  
### Before

User had no way to navigate back to the main page `/` from either the event page `/events` or portfolio page `/portfolio`

### After

Added functionality to the GDSC icon in the navbar as a router button to the main page.